### PR TITLE
Failure to load a model doesn't throw an exception

### DIFF
--- a/projects/app/src/main.cpp
+++ b/projects/app/src/main.cpp
@@ -13,14 +13,16 @@ using namespace bubble;
 
 int main()
 {
+    Loader loader;
+    Ref<Model> teapot = loader.LoadModel("models/teapot.obj");
+    if (!teapot) {
+        return 1;
+    }
+
     Window window( "Bubble", WindowSize{ 1200, 720 } );
     ImGui::SetCurrentContext( window.GetImGuiContext() );
 
-#ifdef __EMSCRIPTEN__
-    EMSCRIPTEN_MAINLOOP_BEGIN
-#else
     while ( !window.ShouldClose() )
-#endif
     {
         window.PollEvents();
         
@@ -32,9 +34,6 @@ int main()
         window.ImGuiEnd();
         window.OnUpdate();
     }
-#ifdef __EMSCRIPTEN__
-    EMSCRIPTEN_MAINLOOP_END;
-#endif
     return 0;
 }
 

--- a/projects/engine/src/loader/model_loader.cpp
+++ b/projects/engine/src/loader/model_loader.cpp
@@ -48,8 +48,11 @@ Ref<Model> Loader::LoadModel( const std::path& path )
 
 	Assimp::Importer importer;
 	const aiScene* scene = importer.ReadFile( path.string(), 0);
-	if ( !scene || ( scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE ) || !scene->mRootNode )
-		throw std::runtime_error( "ERROR::ASSIMP\n" + std::string( importer.GetErrorString() ) );
+	if (!scene || (scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) || !scene->mRootNode)
+	{
+		LogError("ERROR::ASSIMP " + std::string(importer.GetErrorString()));
+		return Ref<Model>();
+	}
 	importer.ApplyPostProcessing( aiProcess_FlipUVs | aiProcessPreset_TargetRealtime_MaxQuality );
 
 	model->mMeshes.reserve( scene->mNumMeshes );


### PR DESCRIPTION
I have no idea why, in the loader at line 53 when returning a `model`, the check `if (!teapot)` stops working.